### PR TITLE
Improving error messages for URL.js polyfill

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -67,27 +67,27 @@ export class URLSearchParams {
   }
 
   delete(name) {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URLSearchParams.delete" is not implemented');
   }
 
   get(name) {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URLSearchParams.get" is not implemented');
   }
 
   getAll(name) {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URLSearchParams.getAll" is not implemented');
   }
 
   has(name) {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URLSearchParams.has" is not implemented');
   }
 
   set(name, value) {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URLSearchParams.set" is not implemented');
   }
 
   sort() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URLSearchParams.sort" is not implemented');
   }
 
   [Symbol.iterator]() {
@@ -156,15 +156,15 @@ export class URL {
   }
 
   get hash() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.hash" is not implemented');
   }
 
   get host() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.host" is not implemented');
   }
 
   get hostname() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.hostname" is not implemented');
   }
 
   get href(): string {
@@ -172,27 +172,27 @@ export class URL {
   }
 
   get origin() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.origin" is not implemented');
   }
 
   get password() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.password" is not implemented');
   }
 
   get pathname() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.pathname" is not implemented');
   }
 
   get port() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.port" is not implemented');
   }
 
   get protocol() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.protocol" is not implemented');
   }
 
   get search() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.search" is not implemented');
   }
 
   get searchParams(): URLSearchParams {
@@ -215,6 +215,6 @@ export class URL {
   }
 
   get username() {
-    throw new Error('not implemented');
+    throw new Error('react-native URL.js polyfill: "URL.username" is not implemented');
   }
 }


### PR DESCRIPTION
## Summary

`URL` and `URLSearchParams` are polyfilled in `URL.js`, but many functions are not implemented to keep the polyfill light-weight.  If your code uses one of these functions, the polyfill will throw a `not implemented` error message.

When a developer hits this issue, it's often a bit hard to track down exactly what's wrong:
* What is `not implemented`?
* My URL parsing code has several calls to `URL`, which one is blowing up?

This PR simply makes the error messages slightly more explicit.  This helps with grepping for your error and faster debugging.

## Changelog:

[General] [Changed] - Improving URL.js polyfill "not implemented" error messages.


## Test Plan

Verify the error message renders correctly in the app simulator.

![Screen Shot 2020-10-09 at 03 45 53 PM](https://user-images.githubusercontent.com/348581/95637436-a65c7e00-0a46-11eb-8142-9f25cdcba94c.png)

## Related

Originally, my tests were passing but the application was blowing up.  To make the tests fail in the same way as the application, I loaded the `URL.js` polyfills in my jest `setup.js` file with the following:

```
import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
import { URL, URLSearchParams } from 'react-native/Libraries/Blob/URL';

polyfillGlobal('URL', () => URL);
polyfillGlobal('URLSearchParams', () => URLSearchParams);
```